### PR TITLE
Add caching to top 10 users data

### DIFF
--- a/classes/task/report_async.php
+++ b/classes/task/report_async.php
@@ -71,6 +71,8 @@ class report_async extends \core\task\scheduled_task {
 
             $transaction->allow_commit();
 
+            // Ignore the result now. The call will only cache the data internally.
+            report_coursesize_get_usersizes();
             set_config('coursesizeupdated', time(), 'report_coursesize');
 
             mtrace("report_coursesize cache updated.");

--- a/db/caches.php
+++ b/db/caches.php
@@ -15,18 +15,20 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version information
+ * Plugin cache definitions.
  *
  * @package    report_coursesize
- * @copyright  2014 Catalyst IT {@link http://www.catalyst.net.nz}
+ * @author     Kateryna Degtyariova <katerynadegtyariova@catalyst-au.net>
+ * @copyright  2022 Catalyst IT {@link http://www.catalyst.net.nz}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2021030808;
-$plugin->requires = 2018120300; // Requires 3.6.
-$plugin->component = 'report_coursesize';
-$plugin->release = '4.1';
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [39, 400];
+$definitions = array(
+    'topuserdata' => array(
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => true,
+        'simpledata' => true,
+    ),
+);

--- a/index.php
+++ b/index.php
@@ -52,9 +52,6 @@ if (!empty($reportconfig->filessize) && !empty($reportconfig->filessizeupdated))
 }
 
 $totalusagereadable = display_size($totalusage);
-
-$usersizes = $DB->get_records_sql(report_coursesize_usersize_sql(), [], 0, REPORT_COURSESIZE_NUMBEROFUSERS);
-
 $systemsize = $systembackupsize = 0;
 
 $coursesql = 'SELECT cx.id, c.id as courseid ' .
@@ -185,8 +182,8 @@ $coursetable->data[] = $row;
 $downloaddata[] = [get_string('total'), '', display_size($totalsize), display_size($totalbackupsize)];
 unset($courses);
 
+$usersizes = report_coursesize_get_usersizes();
 if (!empty($usersizes)) {
-    arsort($usersizes);
     $usertable = new html_table();
     $usertable->align = array('right', 'right');
     $usertable->head = array(get_string('user'), get_string('diskusage', 'report_coursesize'));


### PR DESCRIPTION
The data for top 10 users is cached for 24 hours.