### PR TITLE
Add missing language string for caching

### DIFF
--- a/lang/en/report_coursesize.php
+++ b/lang/en/report_coursesize.php
@@ -23,6 +23,7 @@
  */
 
 $string['backupsize'] = 'Backup size';
+$string['cachedef_topuserdata'] = 'Cached info about the users with the largest total amount of data';
 $string['catsystemuse'] = 'System and category use outside users and courses is {$a}.';
 $string['catsystembackupuse'] = 'System and category backup use is {$a}.';
 $string['coursesize'] = 'Course size';


### PR DESCRIPTION
Using caching object requires creating a string definition in a language file for 'cachedef_topuserdata'