### PR TITLE
Add composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "catalyst-report/coursesize",
+    "description": "This plugin provides approximate disk usage by Moodle courses.",
+    "type": "moodle-report",
+    "require": {
+        "composer/installers": "^2.1"
+    },
+    "license": "http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later"
+}


### PR DESCRIPTION
The type `moodle-report` copies the plugin into the [correct directory when installing with composer](https://github.com/composer/installers/blob/main/src/Composer/Installers/MoodleInstaller.php#L55).