### PR TITLE
#62 - Prevent $course->backupsize from being NULL to avoid deprecation messages

### DIFF
--- a/index.php
+++ b/index.php
@@ -167,12 +167,10 @@ if ($viewtab == 'userstopnum') {
 
     $coursesizes = $DB->get_records('report_coursesize');
     foreach ($courses as $courseid => $course) {
-        if ($live) {
-            if (isset($backupsizes[$course->id])) {
-                $course->backupsize = $backupsizes[$course->id]->filesize;
-            } else {
-                $course->backupsize = 0;
-            }
+        if (isset($backupsizes[$course->id])) {
+            $course->backupsize = $backupsizes[$course->id]->filesize;
+        } else {
+            $course->backupsize = 0;
         }
         $totalsize = $totalsize + $course->filesize;
         $totalbackupsize = $totalbackupsize + $course->backupsize;


### PR DESCRIPTION
$backupsizes also only has elements if we're doing $live updates. So we don't have to check for $live. This lets us remove the check and just reuse the $backupsizes check for all variants (live/not live)
