### PR TITLE
Standardise backup size in exports

### DIFF
--- a/index.php
+++ b/index.php
@@ -160,10 +160,12 @@ if ($viewtab == 'userstopnum') {
     $totalsize = 0;
     $totalbackupsize = 0;
     $downloaddata = [];
-    $downloaddata[] = [get_string('course'),
+    $downloaddata[] = [
+        get_string('course'),
         get_string('category'),
-        get_string('diskusage', 'report_coursesize'),
-        get_string('backupsize', 'report_coursesize')];;
+        get_string('diskusagemb', 'report_coursesize'),
+        get_string('backupsizemb', 'report_coursesize'),
+    ];
 
     $coursesizes = $DB->get_records('report_coursesize');
     foreach ($courses as $courseid => $course) {
@@ -193,8 +195,12 @@ if ($viewtab == 'userstopnum') {
         $row[] = "<span id=\"coursesize_" . $course->shortname . "\" title=\"$bytesused\">$readablesize</span>" . $summary;
         $row[] = "<span title=\"$backupbytesused\">" . display_size($course->backupsize) . "</span>";
         $coursetable->data[] = $row;
-        $downloaddata[] = [$course->shortname, $course->name, str_replace(',', '', $readablesize),
-            str_replace(',', '', display_size($course->backupsize))];
+        $downloaddata[] = [
+            $course->shortname,
+            $course->name,
+            format_float($course->filesize / 1024 / 1024, 2, false),
+            format_float($course->backupsize / 1024 / 1024, 2, false),
+        ];
     }
 
     // Now add the courses that had no sitedata into the table.
@@ -223,7 +229,12 @@ if ($viewtab == 'userstopnum') {
     $row[] = display_size($totalsize);
     $row[] = display_size($totalbackupsize);
     $coursetable->data[] = $row;
-    $downloaddata[] = [get_string('total'), '', display_size($totalsize), display_size($totalbackupsize)];
+    $downloaddata[] = [
+        get_string('total'),
+        '',
+        format_float($totalsize / 1024 / 1024, 2, false),
+        format_float($totalbackupsize / 1024 / 1024, 2, false),
+    ];
     unset($courses);
 
     $systemsizereadable = display_size($systemsize);

--- a/lang/en/report_coursesize.php
+++ b/lang/en/report_coursesize.php
@@ -24,6 +24,7 @@
 
 $string['allcourses'] = 'All courses';
 $string['backupsize'] = 'Backup size';
+$string['backupsizemb'] = 'Backup size (MB)';
 $string['cachedef_topuserdata'] = 'Cached info about the users with the largest total amount of data';
 $string['calcmethod'] = 'Update main report';
 $string['calcmethodcron'] = 'Scheduled task';
@@ -39,6 +40,7 @@ $string['coursesize:view'] = 'View course size report';
 $string['coursesize_desc'] = '<p>This report only provides approximate values, if a file is used multiple times within a course or in multiple courses the report counts each instance even though Moodle only stores one physical version on disk.</p>';
 $string['coursesummary'] = '(view stats)';
 $string['diskusage'] = 'Total';
+$string['diskusagemb'] = 'Total (MB)';
 $string['emptycourseshidden'] = 'Courses that do not use any file storage have been excluded from this report.';
 $string['error_unsupported_branch'] = 'Cannot upgrade this old coursereport plugin - you should check/delete the old table before upgrading to this release.';
 $string['exportcsv'] = 'Export CSV';

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2024112601;
+$plugin->version  = 2024112602;
 $plugin->requires = 2022112800; // Requires 4.1
 $plugin->component = 'report_coursesize';
-$plugin->release  = 2024112601;
+$plugin->release  = 2024112602;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->supported = [401, 405];


### PR DESCRIPTION
Follow up of #65 

As per those discussions, displaying it as MB for a mix of readability and to allow for calculations.