### PR TITLE
Treat zero-file courses/categories as 0 byte

### DIFF
--- a/callback.php
+++ b/callback.php
@@ -80,8 +80,8 @@ $sql = "
         ct.name AS catname,
         ct.parent AS catparent,
         ct.sortorder AS sortorder,
-        rc.filesize AS filesize,
-        rc.backupsize AS backupsize
+        CASE WHEN rc.filesize > 0 THEN rc.filesize ELSE 0 END AS filesize,
+        CASE WHEN rc.backupsize > 0 THEN rc.backupsize ELSE 0 END AS backupsize
     FROM
         {course_categories} ct
         LEFT JOIN {report_coursesize} rc ON ct.id = rc.instanceid AND rc.contextlevel = :ctxcc
@@ -198,8 +198,8 @@ $sql = "
         c.shortname AS courseshortname,
         c.sortorder AS sortorder,
         c.category AS coursecategory,
-        rc.filesize AS filesize,
-        rc.backupsize AS backupsize
+        CASE WHEN rc.filesize > 0 THEN rc.filesize ELSE 0 END AS filesize,
+        CASE WHEN rc.backupsize > 0 THEN rc.backupsize ELSE 0 END AS backupsize
     FROM
         {course} c
         LEFT JOIN {report_coursesize} rc ON c.id = rc.instanceid AND rc.contextlevel = :ctxc

--- a/locallib.php
+++ b/locallib.php
@@ -845,8 +845,8 @@ function report_coursesize_export($displaysize, $sortorder, $sortdir) {
                ct.name AS catname,
                ct.parent AS catparent,
                ct.sortorder AS sortorder,
-               rc.filesize AS filesize,
-               rc.backupsize AS backupsize
+               CASE WHEN rc.filesize > 0 THEN rc.filesize ELSE 0 END AS filesize,
+               CASE WHEN rc.backupsize > 0 THEN rc.backupsize ELSE 0 END AS backupsize
           FROM {course_categories} ct
      LEFT JOIN {report_coursesize} rc
             ON ct.id = rc.instanceid AND rc.contextlevel = :ctxcc';
@@ -923,8 +923,8 @@ function report_coursesize_export($displaysize, $sortorder, $sortdir) {
                c.shortname AS courseshortname,
                c.sortorder AS sortorder,
                c.category AS coursecategory,
-               rc.filesize AS filesize,
-               rc.backupsize AS backupsize
+               CASE WHEN rc.filesize > 0 THEN rc.filesize ELSE 0 END AS filesize,
+               CASE WHEN rc.backupsize > 0 THEN rc.backupsize ELSE 0 END AS backupsize
           FROM {course} c
      LEFT JOIN {report_coursesize} rc
             ON c.id = rc.instanceid AND rc.contextlevel = :ctxc";


### PR DESCRIPTION
SQLs extracting the filesize of courses/categories cannot handle zero-file (not cached in {report_coursesize}) course/categories; they are extracted as NULL and not used appropriately as the sortkey.
This fixes filesize/backupsize to 0 if they are NULL.