### PR TITLE
Issue #81: Added expectOutputRegex() to tests

### DIFF
--- a/tests/calculate_task_test.php
+++ b/tests/calculate_task_test.php
@@ -59,6 +59,8 @@ final class calculate_task_test extends advanced_testcase {
             'filename'  => 'a.txt',
         ], str_repeat('X', 5000));
 
+        $this->expectOutputRegex('/Task complete\./');
+
         $task = manager::get_scheduled_task('\report_coursesize\task\calculate');
         $task->execute();
 
@@ -84,6 +86,7 @@ final class calculate_task_test extends advanced_testcase {
     }
 
     public function test_lastruntime_is_updated(): void {
+        $this->expectOutputRegex('/Task complete\./');
         $task = manager::get_scheduled_task('\report_coursesize\task\calculate');
         $task->execute();
 


### PR DESCRIPTION
Closes issue #81.

Updated `report_coursesize\calculate_task_test.php` to expect the mtrace() output from the task. This output was causing the unexpected output warnings during unit tests

## Environment
```
- Moodle 5.1.3+ (Build: 20260220)
- PHP: 8.4.22
- DB: MySQL 8.4
- Branch: MOODLE_401_STABLE
```

## Testing instructions:
- `report_coursesize` test suite: `vendor/bin/phpunit --testsuite report_coursesize_testsuite`
- Running the unit tests for `report_coursesize` will produce the following warnings (on the above environment):
```
Moodle 5.1.5 (Build: 20260608)
Php: 8.4.22, mysqli: 8.4.9, OS: Linux 6.17.0-1025-oem x86_64
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-mdl/phpunit.xml

.Task complete.
R.Task complete.
R................                                              20 / 20 (100%)

Time: 00:02.616, Memory: 78.50 MB

There were 2 risky tests:

1) report_coursesize\calculate_task_test::test_task_runs_and_populates_tables
Test code or tested code printed unexpected output: Task complete.

/var/www/upstream-mdl/public/report/coursesize/tests/calculate_task_test.php:44

2) report_coursesize\calculate_task_test::test_lastruntime_is_updated
Test code or tested code printed unexpected output: Task complete.

/var/www/upstream-mdl/public/report/coursesize/tests/calculate_task_test.php:86

OK, but there were issues!
Tests: 20, Assertions: 48, PHPUnit Deprecations: 4, Risky: 2.
```
### Expected Output from PHPUnit Tests
- Pulling this branch `MOODLE_401_STABLE-issue81` and re-running the testsuite:
```
Moodle 5.1.5 (Build: 20260608)
Php: 8.4.22, mysqli: 8.4.9, OS: Linux 6.17.0-1025-oem x86_64
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-mdl/phpunit.xml

....................                                              20 / 20 (100%)

Time: 00:02.534, Memory: 78.50 MB

OK, but there were issues!
Tests: 20, Assertions: 50, PHPUnit Deprecations: 4.
```